### PR TITLE
Harden API error handling and make ticket code insertion resilient

### DIFF
--- a/api.php
+++ b/api.php
@@ -51,6 +51,23 @@ function newCode(): string {
     return strtoupper(bin2hex(random_bytes(6)));
 }
 
+function insertTicketWithUniqueCode(PDOStatement $ins, int $eid, string $nom, string $pre, string $ticketLabel): string {
+    $attempts = 0;
+    while ($attempts < 5) {
+        $code = newCode();
+        try {
+            $ins->execute([$eid, $code, $nom, $pre, $ticketLabel]);
+            return $code;
+        } catch (PDOException $e) {
+            if ($e->getCode() !== '23000') {
+                throw $e;
+            }
+            $attempts++;
+        }
+    }
+    throw new RuntimeException('Impossible de générer un code ticket unique.');
+}
+
 // ── CORS ──
 header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
@@ -68,10 +85,10 @@ try {
     route($db, $action);
 } catch (PDOException $e) {
     wlog('ERROR', 'PDO: ' . $e->getMessage());
-    sendJson(['error' => 'Erreur BDD: ' . $e->getMessage()], 500);
+    sendJson(['error' => 'Erreur BDD'], 500);
 } catch (Throwable $e) {
     wlog('ERROR', 'Exception: ' . $e->getMessage(), ['file' => $e->getFile(), 'line' => $e->getLine()]);
-    sendJson(['error' => 'Erreur: ' . $e->getMessage()], 500);
+    sendJson(['error' => 'Erreur serveur'], 500);
 }
 
 // ══════════════════════════════════════════════════════════════
@@ -232,7 +249,7 @@ function route(PDO $db, string $action): void {
             $nb  = max(1, (int)($g['nb_tickets'] ?? 1));
             if (!$nom || !$pre) continue;
             for ($i = 1; $i <= $nb; $i++) {
-                $ins->execute([$eid, newCode(), $nom, $pre, "$i/$nb"]);
+                insertTicketWithUniqueCode($ins, $eid, $nom, $pre, "$i/$nb");
                 $count++;
             }
         }
@@ -253,8 +270,7 @@ function route(PDO $db, string $action): void {
         $ins = $db->prepare("INSERT INTO tickets (event_id,ticket_code,nom,prenom,ticket_label) VALUES (?,?,?,?,?)");
         $codes = [];
         for ($i = 1; $i <= $nb; $i++) {
-            $c = newCode();
-            $ins->execute([$eid, $c, $nom, $pre, "$i/$nb"]);
+            $c = insertTicketWithUniqueCode($ins, $eid, $nom, $pre, "$i/$nb");
             $codes[] = $c;
         }
         wlog('INFO', "Added $pre $nom ($nb) to event $eid");

--- a/config.php
+++ b/config.php
@@ -1,5 +1,5 @@
 <?php
-define('DB_HOST', 
+define('DB_HOST', 'localhost');         // Hôte BDD
 define('DB_NAME', 'dbs15500217');        // Nom de la BDD
 define('DB_USER', ''); // Utilisateur BDD
 define('DB_PASS', ''); // Mot de passe BDD


### PR DESCRIPTION
### Motivation
- Ensure the app ships with a valid `config.php` that parses cleanly in default form by providing a `DB_HOST` placeholder. 
- Prevent leaking internal database or exception messages in HTTP JSON responses while keeping detailed traces in server logs. 
- Make ticket creation robust against rare `ticket_code` uniqueness collisions during bulk import or manual add.

### Description
- Added `insertTicketWithUniqueCode(PDOStatement $ins, int $eid, string $nom, string $pre, string $ticketLabel)` which retries up to 5 times and handles unique-constraint collisions when generating `ticket_code`.
- Replaced direct `INSERT` + `newCode()` usage in `import` and `add_guest` flows to use the new retry helper. 
- Replaced detailed error messages returned to clients with generic messages (`Erreur BDD` and `Erreur serveur`) while preserving full error logs via `wlog`. 
- Fixed a parse error in `config.php` by setting `DB_HOST` to a default placeholder (`'localhost'`).

### Testing
- Ran PHP lint on changed and supporting files with `php -l api.php`, `php -l config.php`, `php -l install.php`, and `php -l upgrade.php`, and all checks reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5f19116e083269d258c9d05deeebf)