### PR TITLE
Persist selected event, prevent duplicate stats polling, and harden UI interactions

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -200,11 +200,16 @@ function fillEvents(list) {
   const sel = document.getElementById('ev-sel');
   if (!list.length) { sel.innerHTML='<option value="">Aucun evenement</option>'; return; }
   sel.innerHTML = list.map(e => '<option value="'+e.id+'">'+esc(e.name)+' ('+e.total_tickets+' tickets)</option>').join('');
-  evId = list[0].id;
+  const saved = parseInt(localStorage.getItem('lt_event_id')||'0',10);
+  const found = list.find(e => parseInt(e.id,10) === saved);
+  evId = found ? found.id : list[0].id;
+  localStorage.setItem('lt_event_id', String(evId));
+  sel.value = String(evId);
   refresh();
 }
 function onEvChange() {
   evId = parseInt(document.getElementById('ev-sel').value)||0;
+  if (evId) localStorage.setItem('lt_event_id', String(evId));
   document.getElementById('edit-form').classList.add('hidden');
   if (evId) refresh();
 }
@@ -265,7 +270,18 @@ function delEv() {
   post('delete_event',{event_id:evId}).then(()=>{evId=0;reloadEvents();});
 }
 function reloadEvents() {
-  api('events').then(d => { fillEvents(d); document.getElementById('ev-sel').value=evId; });
+  api('events').then(d => {
+    fillEvents(d);
+    var preferred = parseInt(localStorage.getItem('lt_event_id') || String(evId), 10);
+    var hasPreferred = d.some(function(e){ return parseInt(e.id,10)===preferred; });
+    if (hasPreferred) {
+      evId = preferred;
+      document.getElementById('ev-sel').value = String(preferred);
+      refresh();
+    } else {
+      document.getElementById('ev-sel').value=evId;
+    }
+  });
 }
 
 // ── Stats ──
@@ -288,13 +304,16 @@ function renderGuests(list) {
   document.getElementById('gtb').innerHTML = list.map(g => {
     const ci = g.checked_in==1;
     const tm = g.checked_in_at ? new Date(g.checked_in_at).toLocaleTimeString('fr-FR') : '';
+    const code = String(g.ticket_code||'');
+    const codeJs = code.replace(/\\/g,'\\\\').replace(/'/g,"\\'");
+    const codeUrl = encodeURIComponent(code);
     return '<tr><td><b>'+esc(g.prenom)+' '+esc(g.nom)+'</b></td><td>'+esc(g.ticket_label)+'</td>'
-      +'<td style="font-family:monospace;font-size:.78rem">'+g.ticket_code+'</td>'
+      +'<td style="font-family:monospace;font-size:.78rem">'+esc(code)+'</td>'
       +'<td>'+(ci?'<span class="badge badge-ok">'+tm+'</span>':'<span class="badge badge-w">Attente</span>')+'</td>'
       +'<td class="acts">'
-      +(ci?'<button class="btn btn-s" style="background:var(--warn)" onclick="resetOne(\''+g.ticket_code+'\')">Reset</button>':'')
-      +'<button class="btn btn-s bp" onclick="window.open(\'api.php?action=ticket_pdf&code='+g.ticket_code+'\')">Ticket</button>'
-      +'<button class="btn btn-s bd" onclick="delTicket(\''+g.ticket_code+'\')">X</button>'
+      +(ci?'<button class="btn btn-s" style="background:var(--warn)" onclick="resetOne(\''+codeJs+'\')">Reset</button>':'')
+      +'<button class="btn btn-s bp" onclick="window.open(\'api.php?action=ticket_pdf&code='+codeUrl+'\',\'_blank\',\'noopener\')">Ticket</button>'
+      +'<button class="btn btn-s bd" onclick="delTicket(\''+codeJs+'\')">X</button>'
       +'</td></tr>';
   }).join('') || '<tr><td colspan="5" style="text-align:center;color:var(--mut);padding:20px">Aucun ticket</td></tr>';
 }
@@ -315,7 +334,10 @@ function addGuest() {
   if(!nom||!pre){msg('ag-msg','er','Nom et prenom requis');return;}
   post('add_guest',{event_id:evId,nom:nom,prenom:pre,nb_tickets:nb}).then(d => {
     if(d.error){msg('ag-msg','er',d.error);return;}
-    const links=d.codes.map(c=>'<a href="api.php?action=ticket_pdf&code='+c+'" target="_blank">'+c+'</a>').join(' ');
+    const links=d.codes.map(c=>{
+      const ec=esc(c), u=encodeURIComponent(c);
+      return '<a href="api.php?action=ticket_pdf&code='+u+'" target="_blank" rel="noopener">'+ec+'</a>';
+    }).join(' ');
     msg('ag-msg','ok',d.count+' ticket(s): '+links);
     document.getElementById('ag-nom').value='';document.getElementById('ag-pre').value='';document.getElementById('ag-nb').value='1';
     refresh();

--- a/index.html
+++ b/index.html
@@ -124,18 +124,22 @@ header .stats .n{font-weight:700;font-size:1.05rem}
 </div>
 
 <script>
-var A='api.php',evId=0,paused=false,sc=null;
+var A='api.php',evId=0,paused=false,sc=null,statsTimer=null;
 
 // Init
 fetch(A+'?action=events').then(r=>r.json()).then(evts=>{
   var el=document.getElementById('ev-list');
   if(!evts.length){el.innerHTML='<p style="color:var(--mut)">Aucun evenement. <a href="admin.html">Creez-en un</a>.</p>';return;}
+  var last=parseInt(localStorage.getItem('lt_event_id')||'0',10);
+  var prev=evts.find(function(e){return parseInt(e.id,10)===last;});
+  if(prev){pick(prev);return;}
   if(evts.length===1){pick(evts[0]);return;}
   el.innerHTML=evts.map(function(e){return '<div class="ev-btn" onclick=\'pick('+JSON.stringify(e).replace(/'/g,"&#39;")+')\' ><b>'+esc(e.name)+'</b><span>'+esc([e.event_date,e.location].filter(Boolean).join(' - '))+' — '+e.total_tickets+' tickets</span></div>';}).join('');
 }).catch(function(e){document.getElementById('ev-list').innerHTML='<p style="color:var(--err)">Erreur: '+esc(String(e))+'</p>';});
 
 function pick(ev){
   evId=ev.id;
+  localStorage.setItem('lt_event_id',String(ev.id));
   document.getElementById('hdr-name').textContent=ev.name||'Scanner';
   document.getElementById('hdr-sub').textContent=[ev.event_date,ev.location].filter(Boolean).join('  —  ');
   document.getElementById('picker').style.display='none';
@@ -143,7 +147,8 @@ function pick(ev){
   document.getElementById('hdr-stats').style.display='flex';
   document.getElementById('nav').classList.add('show');
   reStats();loadHist();initCam();
-  setInterval(reStats,30000);
+  if(statsTimer)clearInterval(statsTimer);
+  statsTimer=setInterval(reStats,30000);
 }
 
 function reStats(){
@@ -211,9 +216,12 @@ function doSearch(q){
 function renderList(list){
   document.getElementById('sres').innerHTML=list.map(function(g){
     var ci=g.checked_in==1;
-    return '<div class="gi"><div><b>'+esc(g.prenom)+' '+esc(g.nom)+'</b><div class="c">Ticket '+esc(g.ticket_label)+' — '+g.ticket_code+'</div></div><div>'
-      +(ci?'<span class="ok">Entre</span>':'<span class="w">Attente</span><button class="mb" onclick="doCheckin(\''+g.ticket_code+'\',\'manual\')">Valider</button>')
-      +'<button class="tb" onclick="window.open(\'api.php?action=ticket_pdf&code='+g.ticket_code+'\')">Ticket</button>'
+    var code=String(g.ticket_code||'');
+    var codeEsc=esc(code);
+    var codeJs=code.replace(/\\/g,'\\\\').replace(/'/g,"\\'");
+    return '<div class="gi"><div><b>'+esc(g.prenom)+' '+esc(g.nom)+'</b><div class="c">Ticket '+esc(g.ticket_label)+' — '+codeEsc+'</div></div><div>'
+      +(ci?'<span class="ok">Entre</span>':'<span class="w">Attente</span><button class="mb" onclick="doCheckin(\''+codeJs+'\',\'manual\')">Valider</button>')
+      +'<button class="tb" onclick="window.open(\'api.php?action=ticket_pdf&code='+encodeURIComponent(code)+'\',\'_blank\',\'noopener\')">Ticket</button>'
       +'</div></div>';
   }).join('')||'<div style="text-align:center;color:var(--mut);padding:16px">Aucun resultat</div>';
 }
@@ -230,7 +238,7 @@ function quickAdd(){
   fetch(A+'?action=add_guest',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({event_id:evId,nom:nom,prenom:pre,nb_tickets:nb,password:pass})})
   .then(function(r){return r.json();}).then(function(d){
     if(d.error){m.innerHTML='<span style="color:var(--err)">'+esc(d.error)+'</span>';sessionStorage.removeItem('ap');return;}
-    var links=d.codes.map(function(c){return '<a href="api.php?action=ticket_pdf&code='+c+'" target="_blank">'+c+'</a>';}).join(' ');
+    var links=d.codes.map(function(c){var ec=esc(c);return '<a href="api.php?action=ticket_pdf&code='+encodeURIComponent(c)+'" target="_blank" rel="noopener">'+ec+'</a>';}).join(' ');
     m.innerHTML='<span style="color:var(--ok)">'+d.count+' ticket(s)</span> '+links;
     document.getElementById('qa-n').value='';document.getElementById('qa-p').value='';document.getElementById('qa-nb').value='1';
     reStats();

--- a/tickets.html
+++ b/tickets.html
@@ -58,14 +58,33 @@ body{font-family:Georgia,'Times New Roman',serif;background:#f5f0e6}
   <h1>Tous les Tickets</h1>
   <button onclick="window.print()">Imprimer / PDF</button>
   <button onclick="load()">Recharger</button>
+  <select id="ev-sel" onchange="onEventChange()" style="margin-left:8px;padding:6px 8px;border-radius:6px;border:none;max-width:280px"></select>
   <div id="info">Chargement...</div>
   <a href="admin.html">Admin</a>
 </div>
 <div class="wrap" id="wrap"><div style="padding:40px;color:#888;font-family:system-ui">Chargement...</div></div>
 <script>
-var A='api.php',eid=new URLSearchParams(location.search).get('event_id')||1;
+var A='api.php',eid=parseInt(new URLSearchParams(location.search).get('event_id')||localStorage.getItem('lt_event_id')||'0',10)||0;
+
+function loadEvents(){
+  return fetch(A+'?action=events').then(function(r){return r.json();}).then(function(events){
+    var sel=document.getElementById('ev-sel');
+    if(!events.length){
+      sel.innerHTML='<option value="">Aucun evenement</option>';
+      document.getElementById('info').textContent='Aucun evenement';
+      return null;
+    }
+    sel.innerHTML=events.map(function(e){return '<option value="'+e.id+'">'+esc(e.name)+'</option>';}).join('');
+    var found=events.find(function(e){return parseInt(e.id,10)===eid;});
+    if(!found){eid=parseInt(events[0].id,10);}
+    sel.value=String(eid);
+    localStorage.setItem('lt_event_id',String(eid));
+    return true;
+  });
+}
 
 function load(){
+  if(!eid){document.getElementById('info').textContent='Selectionnez un evenement';return;}
   Promise.all([
     fetch(A+'?action=event&event_id='+eid).then(function(r){return r.json();}),
     fetch(A+'?action=guests&event_id='+eid).then(function(r){return r.json();})
@@ -84,6 +103,7 @@ function load(){
       var logoHtml=logo?'<img class="logo" src="'+esc(logo)+'" alt="">':'';
       var descHtml=desc?'<div class="ed">'+esc(desc)+'</div>':'';
       var qrId='qr'+idx;
+      var code = String(g.ticket_code||'');
       d.innerHTML=
         '<div class="tk-band">'+logoHtml+'<div class="en">'+esc(name)+'</div>'
         +(sub?'<div class="es">'+esc(sub)+'</div>':'')
@@ -92,21 +112,26 @@ function load(){
         +'<div class="tk-stars">★ ★ ★ ★ ★</div>'
         +'<div class="tk-body">'
         +'<div class="tk-info"><div class="tk-name">'+esc(g.prenom)+' '+esc(g.nom)+'</div><div class="tk-sub">Ticket '+esc(g.ticket_label)+'</div></div>'
-        +'<div class="tk-qr"><div id="'+qrId+'"></div><div class="tk-code">'+g.ticket_code+'</div></div>'
+        +'<div class="tk-qr"><div id="'+qrId+'"></div><div class="tk-code">'+esc(code)+'</div></div>'
         +'</div>'
         +'<div class="tk-foot">★ 1 ticket = 1 entree ★</div>';
       w.appendChild(d);
 
       new QRCode(document.getElementById(qrId),{
-        text:g.ticket_code, width:80, height:80,
+        text:code, width:80, height:80,
         colorDark:'#1a1a2e', colorLight:'#FFF8E7',
         correctLevel:QRCode.CorrectLevel.M
       });
     });
   });
 }
+function onEventChange(){
+  eid=parseInt(document.getElementById('ev-sel').value,10)||0;
+  localStorage.setItem('lt_event_id',String(eid));
+  load();
+}
 function esc(s){var d=document.createElement('div');d.textContent=s;return d.innerHTML;}
-load();
+loadEvents().then(function(ok){if(ok)load();});
 </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Reduce friction on day-of operations by remembering the last selected event across the scanner, admin, and printable tickets pages so operators don't re-select events repeatedly. 
- Prevent accidental duplicate background polling when an event is selected multiple times, which could cause extra network load or confusing UI updates. 
- Harden UI interactions around ticket codes and external links to avoid injection/formatting issues and improve safety when opening ticket PDFs.

### Description
- Persist the last selected event id in `localStorage` under `lt_event_id` and restore it in `index.html`, `admin.html`, and `tickets.html` to streamline event selection.  
- Replace naive `setInterval` usage with a single `statsTimer` so selecting an event clears any existing interval before starting a new one in `index.html`.  
- Sanitize and normalize ticket codes when rendering lists and building inline JS handlers by coercing to `String()`, escaping HTML via `esc(...)`, and escaping JS single-quotes/backslashes before embedding codes in inline `onclick` calls.  
- Use `encodeURIComponent(...)` for ticket URLs and open them with `window.open(..., '_blank', 'noopener')` (and add `rel=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d61c4de2e8832692186d646de29f75)