### PR TITLE
Fix scanner list refresh and prevent duplicate check-ins

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ header .stats .n{font-weight:700;font-size:1.05rem}
 </div>
 
 <script>
-var A='api.php',evId=0,paused=false,sc=null,statsTimer=null;
+var A='api.php',evId=0,paused=false,sc=null,statsTimer=null,checkinInFlight=false;
 
 // Init
 fetch(A+'?action=events').then(r=>r.json()).then(evts=>{
@@ -178,6 +178,8 @@ function manSub(){var i=document.getElementById('mc'),c=i.value.trim().toUpperCa
 document.addEventListener('keydown',function(e){if(e.key==='Enter'&&document.activeElement.id==='mc')manSub();if(e.key==='Escape')closeRes();});
 
 function doCheckin(code,method){
+  if(checkinInFlight)return;
+  checkinInFlight=true;
   var rc=document.getElementById('rc'),ri=document.getElementById('ri'),rs=document.getElementById('rs'),rn=document.getElementById('rn'),rd=document.getElementById('rd');
   rc.className='rcard';
   fetch(A+'?action=checkin',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({event_id:evId,code:code,method:method})})
@@ -187,8 +189,10 @@ function doCheckin(code,method){
     else if(d.status==='duplicate'){var t=d.checked_in_at?new Date(d.checked_in_at).toLocaleTimeString('fr-FR'):'';rc.classList.add('dup');ri.textContent='⚠️';rs.textContent='DEJA SCANNE';rn.textContent=d.prenom+' '+d.nom;rd.textContent='Ticket '+d.ticket_label+' — '+t;}
     else if(d.status==='valid'){rc.classList.add('valid');ri.textContent='✅';rs.textContent='ENTREE VALIDEE';rn.textContent=d.prenom+' '+d.nom;rd.textContent='Ticket '+d.ticket_label;reStats();loadHist();}
     else{rc.classList.add('bad');ri.textContent='❓';rs.textContent='ERREUR';rn.textContent='';rd.textContent=JSON.stringify(d);}
+    refreshListIfOpen();
   })
-  .catch(function(){rc.classList.add('bad');ri.textContent='🔌';rs.textContent='ERREUR RESEAU';rn.textContent='';rd.textContent='Verifiez la connexion';});
+  .catch(function(){rc.classList.add('bad');ri.textContent='🔌';rs.textContent='ERREUR RESEAU';rn.textContent='';rd.textContent='Verifiez la connexion';})
+  .finally(function(){checkinInFlight=false;});
   document.getElementById('ov').classList.add('show');
 }
 function closeRes(){document.getElementById('ov').classList.remove('show');paused=false;}
@@ -224,6 +228,11 @@ function renderList(list){
       +'<button class="tb" onclick="window.open(\'api.php?action=ticket_pdf&code='+encodeURIComponent(code)+'\',\'_blank\',\'noopener\')">Ticket</button>'
       +'</div></div>';
   }).join('')||'<div style="text-align:center;color:var(--mut);padding:16px">Aucun resultat</div>';
+}
+
+function refreshListIfOpen(){
+  if(document.getElementById('search').style.display!=='block')return;
+  doSearch(document.getElementById('sq').value.trim());
 }
 
 // Quick add


### PR DESCRIPTION
### Motivation
- The guest list in the scanner UI did not refresh after validating a ticket from the "Liste" tab, leaving entries showing `Attente` and allowing a second click that returns an `already scanned`/duplicate error.
- Rapid repeat taps could send duplicate check-in requests while a prior request was still in flight.

### Description
- Added a client-side in-flight guard variable `checkinInFlight` and early-return in `doCheckin` to block duplicate submissions while a check-in request is pending.
- Call `refreshListIfOpen()` after any check-in response to refresh the visible guest list when the **Liste** tab is active so the UI updates `Attente` → `Entre` immediately.
- Implemented `refreshListIfOpen()` to re-run `doSearch(...)` only when the search/list panel is visible.
- Ensure `checkinInFlight` is cleared in a `.finally()` handler so the guard resets after success or failure.

### Testing
- No automated tests are present for this project, so no automated test runs were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6533815b483268a4870c9f3fe0c04)