### PR TITLE
Fix scanner event picker so multiple events remain selectable

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,9 +130,6 @@ var A='api.php',evId=0,paused=false,sc=null,statsTimer=null,checkinInFlight=fals
 fetch(A+'?action=events').then(r=>r.json()).then(evts=>{
   var el=document.getElementById('ev-list');
   if(!evts.length){el.innerHTML='<p style="color:var(--mut)">Aucun evenement. <a href="admin.html">Creez-en un</a>.</p>';return;}
-  var last=parseInt(localStorage.getItem('lt_event_id')||'0',10);
-  var prev=evts.find(function(e){return parseInt(e.id,10)===last;});
-  if(prev){pick(prev);return;}
   if(evts.length===1){pick(evts[0]);return;}
   el.innerHTML=evts.map(function(e){return '<div class="ev-btn" onclick=\'pick('+JSON.stringify(e).replace(/'/g,"&#39;")+')\' ><b>'+esc(e.name)+'</b><span>'+esc([e.event_date,e.location].filter(Boolean).join(' - '))+' — '+e.total_tickets+' tickets</span></div>';}).join('');
 }).catch(function(e){document.getElementById('ev-list').innerHTML='<p style="color:var(--err)">Erreur: '+esc(String(e))+'</p>';});


### PR DESCRIPTION
### Motivation

- The scanner would auto-select the previously saved event on startup even when multiple events exist, preventing the user from choosing the event to scan; the change restores manual selection when more than one event is available.

### Description

- Removed the startup logic that auto-selected the saved `lt_event_id` when multiple events are returned, and now only auto-picks when there is exactly one event. 
- Updated the event initialization flow in `index.html` so the picker is shown when multiple events exist, allowing the user to call `pick()` manually.

### Testing

- Applied the patch and validated the file update for `index.html` and inspected the changed lines to confirm the removed auto-selection logic. 
- Verified the updated initialization behavior by reviewing the modified code region; automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6571c490c8326b6c7476508e1ea8b)