### PR TITLE
Add non-QR event mode and restore landing language selector

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -83,6 +83,7 @@ textarea{height:130px;font-family:monospace;font-size:.82rem}
       </div>
       <label>Lieu</label><input type="text" id="ce-loc" placeholder="Salle des Fetes">
       <label>Description</label><textarea id="ce-desc" style="height:60px" placeholder="Stage de Lindy Hop pour tous niveaux..."></textarea>
+      <label style="display:flex;align-items:center;gap:8px;color:var(--txt);margin-top:10px"><input type="checkbox" id="ce-non-qr" style="width:auto">Evenement sans QR code</label>
       <button class="btn bs btn-s" onclick="createEv()">Creer</button>
       <button class="btn bo btn-s" onclick="hideCreate()">Annuler</button>
     </div>
@@ -96,6 +97,7 @@ textarea{height:130px;font-family:monospace;font-size:.82rem}
       <label>Description</label><textarea id="ee-desc" style="height:60px"></textarea>
       <label>Logo (URL de l'image)</label>
       <input type="text" id="ee-logo-url" placeholder="https://example.com/logo.png">
+      <label style="display:flex;align-items:center;gap:8px;color:var(--txt);margin-top:10px"><input type="checkbox" id="ee-non-qr" style="width:auto">Evenement sans QR code</label>
       <div style="display:flex;gap:8px;align-items:center;margin-top:6px">
         <span style="font-size:.78rem;color:var(--mut)">ou uploader :</span>
         <input type="file" id="ee-logo-file" accept="image/*" style="flex:1;font-size:.8rem">
@@ -234,6 +236,7 @@ function createEv() {
     event_date: document.getElementById('ce-date').value,
     location: document.getElementById('ce-loc').value,
     description: document.getElementById('ce-desc').value,
+    non_qrcode_event: document.getElementById('ce-non-qr').checked ? 1 : 0,
   }).then(d => {
     if (d.error) return alert(d.error);
     evId = d.event_id; hideCreate(); reloadEvents();
@@ -249,6 +252,7 @@ function toggleEdit() {
       document.getElementById('ee-loc').value = e.location||'';
       document.getElementById('ee-desc').value = e.description||'';
       document.getElementById('ee-logo-url').value = e.logo_url||'';
+      document.getElementById('ee-non-qr').checked = (parseInt(e.non_qrcode_event,10) || 0) === 1;
       var pv = document.getElementById('ee-logo-preview');
       pv.innerHTML = e.logo_url ? '<img src="'+esc(e.logo_url)+'" style="max-height:60px;border-radius:6px">' : '<span style="color:var(--mut);font-size:.82rem">Aucun logo</span>';
     });
@@ -262,6 +266,7 @@ function saveEv() {
     location:document.getElementById('ee-loc').value,
     description:document.getElementById('ee-desc').value,
     logo_url:document.getElementById('ee-logo-url').value,
+    non_qrcode_event: document.getElementById('ee-non-qr').checked ? 1 : 0,
   }).then(d => { msg('ee-msg',d.error?'er':'ok',d.error||'OK'); reloadEvents(); });
 }
 function uploadLogo() {

--- a/api.php
+++ b/api.php
@@ -124,8 +124,9 @@ function route(PDO $db, string $action): void {
         $b = getBody();
         $name = trim($b['name'] ?? '');
         if ($name === '') sendJson(['error' => 'Nom requis'], 400);
-        $st = $db->prepare("INSERT INTO events (name, event_date, location, description, logo_url) VALUES (?, ?, ?, ?, ?)");
-        $st->execute([$name, trim($b['event_date'] ?? ''), trim($b['location'] ?? ''), trim($b['description'] ?? ''), trim($b['logo_url'] ?? '')]);
+        $nonQr = !empty($b['non_qrcode_event']) ? 1 : 0;
+        $st = $db->prepare("INSERT INTO events (name, event_date, location, description, logo_url, non_qrcode_event) VALUES (?, ?, ?, ?, ?, ?)");
+        $st->execute([$name, trim($b['event_date'] ?? ''), trim($b['location'] ?? ''), trim($b['description'] ?? ''), trim($b['logo_url'] ?? ''), $nonQr]);
         $id = (int)$db->lastInsertId();
         wlog('INFO', "Event created #$id: $name");
         sendJson(['status' => 'ok', 'event_id' => $id]);
@@ -135,8 +136,9 @@ function route(PDO $db, string $action): void {
         $b = getBody();
         $eid = (int)($b['event_id'] ?? 0);
         if (!$eid) sendJson(['error' => 'event_id requis'], 400);
-        $st = $db->prepare("UPDATE events SET name=?, event_date=?, location=?, description=?, logo_url=? WHERE id=?");
-        $st->execute([trim($b['name'] ?? ''), trim($b['event_date'] ?? ''), trim($b['location'] ?? ''), trim($b['description'] ?? ''), trim($b['logo_url'] ?? ''), $eid]);
+        $nonQr = !empty($b['non_qrcode_event']) ? 1 : 0;
+        $st = $db->prepare("UPDATE events SET name=?, event_date=?, location=?, description=?, logo_url=?, non_qrcode_event=? WHERE id=?");
+        $st->execute([trim($b['name'] ?? ''), trim($b['event_date'] ?? ''), trim($b['location'] ?? ''), trim($b['description'] ?? ''), trim($b['logo_url'] ?? ''), $nonQr, $eid]);
         wlog('INFO', "Event updated #$eid");
         sendJson(['status' => 'ok']);
 

--- a/index.html
+++ b/index.html
@@ -5,15 +5,18 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <title>Scanner — Lindy Tickets</title>
 <script src="https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js"></script>
+<script src="ui-translations.js"></script>
 <style>
 :root{--pri:#1a1a2e;--acc:#e94560;--ok:#27ae60;--warn:#f39c12;--err:#e74c3c;--bg:#f0f2f5;--card:#fff;--txt:#333;--mut:#888}
 *{box-sizing:border-box;margin:0;padding:0}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--bg);color:var(--txt);min-height:100dvh;padding-bottom:80px}
 header{background:var(--pri);color:#fff;padding:14px 18px;text-align:center;position:sticky;top:0;z-index:100}
+header .top{display:flex;justify-content:space-between;align-items:center;gap:10px}
 header h1{font-size:1.1rem}
 header .sub{font-size:.78rem;opacity:.7;margin-top:2px}
 header .stats{display:flex;justify-content:center;gap:22px;margin-top:8px;font-size:.82rem}
 header .stats .n{font-weight:700;font-size:1.05rem}
+.lang-sel{width:auto;background:#fff;color:#222;border-radius:6px;border:none;padding:5px 8px;font-size:.78rem}
 
 #picker{padding:20px;text-align:center}
 #picker h2{font-size:1rem;margin-bottom:12px}
@@ -81,24 +84,31 @@ header .stats .n{font-weight:700;font-size:1.05rem}
 <body>
 
 <header>
-  <h1 id="hdr-name">Lindy Tickets</h1>
+  <div class="top">
+    <h1 id="hdr-name">Lindy Tickets</h1>
+    <select id="lang" class="lang-sel" onchange="setLang(this.value)">
+      <option value="fr">FR</option>
+      <option value="en">EN</option>
+      <option value="de">DE</option>
+    </select>
+  </div>
   <div class="sub" id="hdr-sub"></div>
   <div class="stats" id="hdr-stats" style="display:none">
-    <div>Entrees <span class="n" id="s-i">-</span></div>
-    <div>Restants <span class="n" id="s-r">-</span></div>
-    <div>Total <span class="n" id="s-t">-</span></div>
+    <div><span data-i18n="entries">Entrees</span> <span class="n" id="s-i">-</span></div>
+    <div><span data-i18n="remaining">Restants</span> <span class="n" id="s-r">-</span></div>
+    <div><span data-i18n="total">Total</span> <span class="n" id="s-t">-</span></div>
   </div>
 </header>
 
 <!-- Event picker -->
-<div id="picker"><h2>Choisir un evenement</h2><div class="ev-list" id="ev-list">Chargement...</div></div>
+<div id="picker"><h2 data-i18n="choose_event">Choisir un evenement</h2><div class="ev-list" id="ev-list">Chargement...</div></div>
 
 <!-- Main app -->
 <div id="main">
   <div id="cam"><div id="reader"></div><div id="cam-err" style="display:none"></div></div>
-  <div class="sep">ou saisir le code</div>
+  <div class="sep" data-i18n="or_enter_code">ou saisir le code</div>
   <div class="me"><input type="text" id="mc" placeholder="Code ticket" maxlength="12" autocomplete="off"><button onclick="manSub()">OK</button></div>
-  <div id="hist"><h3>Derniers scans</h3><div id="hlist"></div></div>
+  <div id="hist"><h3 data-i18n="last_scans">Derniers scans</h3><div id="hlist"></div></div>
 </div>
 
 <div id="search"><input type="text" id="sq" placeholder="Rechercher..." autocomplete="off"><div id="sres"></div></div>
@@ -124,7 +134,16 @@ header .stats .n{font-weight:700;font-size:1.05rem}
 </div>
 
 <script>
-var A='api.php',evId=0,paused=false,sc=null,currentListQuery='',pendingCheckins={};
+var A='api.php',evId=0,paused=false,sc=null,currentListQuery='',pendingCheckins={},lang=LTTranslations.normalizeLang(localStorage.getItem('lt_lang')||'fr');
+function t(k){ return LTTranslations.t(lang,k); }
+function setLang(l){ lang=LTTranslations.normalizeLang(l); localStorage.setItem('lt_lang',lang); applyI18n(); if(evId)loadHist(); }
+function applyI18n(){
+  document.documentElement.lang=lang;
+  document.getElementById('lang').value=lang;
+  document.querySelectorAll('[data-i18n]').forEach(function(el){ el.textContent=t(el.dataset.i18n); });
+  document.getElementById('sq').placeholder=t('search');
+}
+applyI18n();
 
 // Init
 fetch(A+'?action=events').then(r=>r.json()).then(evts=>{
@@ -139,10 +158,17 @@ function pick(ev){
   document.getElementById('hdr-name').textContent=ev.name||'Scanner';
   document.getElementById('hdr-sub').textContent=[ev.event_date,ev.location].filter(Boolean).join('  —  ');
   document.getElementById('picker').style.display='none';
-  document.getElementById('main').style.display='block';
   document.getElementById('hdr-stats').style.display='flex';
   document.getElementById('nav').classList.add('show');
-  reStats();loadHist();initCam();
+  if((parseInt(ev.non_qrcode_event,10)||0)===1){
+    document.querySelector('[data-t="scan"]').style.display='none';
+    tab('list');
+  } else {
+    document.querySelector('[data-t="scan"]').style.display='';
+    tab('scan');
+    initCam();
+  }
+  reStats();loadHist();
   setInterval(reStats,30000);
 }
 
@@ -198,7 +224,7 @@ function loadHist(){
     document.getElementById('hlist').innerHTML=rows.map(function(h){
       var t=new Date(h.checked_in_at).toLocaleTimeString('fr-FR');
       return '<div class="hi"><b>'+esc(h.prenom)+' '+esc(h.nom)+'</b><span>'+t+'</span></div>';
-    }).join('')||'<div style="text-align:center;color:var(--mut);padding:16px">Aucun scan</div>';
+    }).join('')||'<div style="text-align:center;color:var(--mut);padding:16px">'+esc(t('no_scans'))+'</div>';
   }).catch(function(){});
 }
 

--- a/schema.sql
+++ b/schema.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS `events` (
     `location` VARCHAR(255) DEFAULT '',
     `description` TEXT DEFAULT NULL,
     `logo_url` VARCHAR(500) DEFAULT '',
+    `non_qrcode_event` TINYINT(1) NOT NULL DEFAULT 0,
     `archived` TINYINT(1) NOT NULL DEFAULT 0,
     `created_at` DATETIME DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/ticket_template.php
+++ b/ticket_template.php
@@ -9,6 +9,7 @@ $logo  = $tk['logo_url'] ?? '';
 $name  = $h($tk['prenom'] . ' ' . $tk['nom']);
 $label = $h($tk['ticket_label']);
 $code  = $h($tk['ticket_code']);
+$nonQr = !empty($tk['non_qrcode_event']);
 $url   = SITE_URL;
 ?>
 <!DOCTYPE html>
@@ -17,7 +18,9 @@ $url   = SITE_URL;
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
 <title>Ticket — <?= $name ?></title>
+<?php if (!$nonQr): ?>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+<?php endif; ?>
 <style>
 @page { size: 160mm 110mm; margin: 0; }
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -152,12 +155,17 @@ body {
             <div class="tnum">Ticket <?= $label ?></div>
         </div>
         <div class="qr-box">
+<?php if ($nonQr): ?>
+            <div style="font-size:12px;color:#8B0000;font-family:system-ui">Sans QR code</div>
+<?php else: ?>
             <div id="qr"></div>
             <div class="qr-code"><?= $code ?></div>
+<?php endif; ?>
         </div>
     </div>
     <div class="footer">★ Pr&eacute;sentez ce ticket &agrave; l'entr&eacute;e &mdash; 1 ticket = 1 entr&eacute;e ★</div>
 </div>
+<?php if (!$nonQr): ?>
 <script>
 new QRCode(document.getElementById('qr'), {
     text: "<?= $code ?>",
@@ -166,5 +174,6 @@ new QRCode(document.getElementById('qr'), {
     correctLevel: QRCode.CorrectLevel.M
 });
 </script>
+<?php endif; ?>
 </body>
 </html>

--- a/tickets.html
+++ b/tickets.html
@@ -104,6 +104,7 @@ function load(){
       var descHtml=desc?'<div class="ed">'+esc(desc)+'</div>':'';
       var qrId='qr'+idx;
       var code = String(g.ticket_code||'');
+      var isNonQr=(parseInt(ev.non_qrcode_event,10)||0)===1;
       d.innerHTML=
         '<div class="tk-band">'+logoHtml+'<div class="en">'+esc(name)+'</div>'
         +(sub?'<div class="es">'+esc(sub)+'</div>':'')
@@ -112,16 +113,18 @@ function load(){
         +'<div class="tk-stars">★ ★ ★ ★ ★</div>'
         +'<div class="tk-body">'
         +'<div class="tk-info"><div class="tk-name">'+esc(g.prenom)+' '+esc(g.nom)+'</div><div class="tk-sub">Ticket '+esc(g.ticket_label)+'</div></div>'
-        +'<div class="tk-qr"><div id="'+qrId+'"></div><div class="tk-code">'+esc(code)+'</div></div>'
+        +'<div class="tk-qr">' + (isNonQr ? '<div style="font-size:.72rem;color:#8B0000;font-family:system-ui">Sans QR code</div>' : '<div id="'+qrId+'"></div><div class="tk-code">'+esc(code)+'</div>') + '</div>'
         +'</div>'
         +'<div class="tk-foot">★ 1 ticket = 1 entree ★</div>';
       w.appendChild(d);
 
-      new QRCode(document.getElementById(qrId),{
-        text:code, width:80, height:80,
-        colorDark:'#1a1a2e', colorLight:'#FFF8E7',
-        correctLevel:QRCode.CorrectLevel.M
-      });
+      if(!isNonQr){
+        new QRCode(document.getElementById(qrId),{
+          text:code, width:80, height:80,
+          colorDark:'#1a1a2e', colorLight:'#FFF8E7',
+          correctLevel:QRCode.CorrectLevel.M
+        });
+      }
     });
   });
 }

--- a/upgrade.php
+++ b/upgrade.php
@@ -11,6 +11,10 @@ try {
     $db->exec("ALTER TABLE events ADD COLUMN logo_url VARCHAR(500) DEFAULT '' AFTER description");
     $msgs[] = "Colonne logo_url ajoutee";
 } catch (PDOException $e) { $msgs[] = "logo_url: " . $e->getMessage(); }
+try {
+    $db->exec("ALTER TABLE events ADD COLUMN non_qrcode_event TINYINT(1) NOT NULL DEFAULT 0 AFTER logo_url");
+    $msgs[] = "Colonne non_qrcode_event ajoutee";
+} catch (PDOException $e) { $msgs[] = "non_qrcode_event: " . $e->getMessage(); }
 ?>
 <!DOCTYPE html><html><head><meta charset="UTF-8"><title>Upgrade</title></head><body style="font-family:sans-serif;max-width:500px;margin:40px auto;padding:20px">
 <h1>Upgrade v3.1</h1>


### PR DESCRIPTION
### Motivation
- Add support for events that should not use QR codes so organisers can generate "non-QR" ticket batches. 
- When an event is non-QR, the app must open the guest list instead of the scanner to avoid presenting a useless scanner UI. 
- Restore and wire the landing-page language switcher so translations and placeholders work on the scanner page.

### Description
- Added `non_qrcode_event` column to the `events` table (`schema.sql`) and included an `ALTER TABLE` step in `upgrade.php` for existing installs. 
- Wire `non_qrcode_event` through the API in `create_event` and `update_event` so the flag is persisted from the admin UI (`api.php`).
- Admin UI (`admin.html`) now has a checkbox in create/edit forms to mark an event as "Evenement sans QR code" and sends/reads the flag when creating or editing events. 
- Scanner landing page (`index.html`) now includes the language selector (`ui-translations.js`) and i18n wiring, and switches to the `list` tab (hiding the `scan` tab) for events with `non_qrcode_event=1`; otherwise the camera is initialised as before. 
- Ticket rendering updated: `tickets.html` and `ticket_template.php` omit QR generation and show a "Sans QR code" indicator for non-QR events, and the single-ticket template avoids loading the QR script when not needed.

### Testing
- Ran PHP lint checks: `php -l api.php`, `php -l ticket_template.php`, `php -l upgrade.php`, `php -l install.php`, all returned "No syntax errors detected" (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddeda45554832692ed53acb8c1efc3)