### PR TITLE
Unifie génération PDF des tickets et ajoute export multi-sélection (A4 portrait)

### DIFF
--- a/api.php
+++ b/api.php
@@ -347,12 +347,42 @@ function route(PDO $db, string $action): void {
     // ── TICKET PDF ──────────────────────────────────────────
 
     case 'ticket_pdf':
-        $code = strtoupper(trim($_GET['code'] ?? ''));
-        if (!$code) { http_response_code(400); echo 'Code manquant'; exit; }
-        $st = $db->prepare("SELECT t.*,e.name AS event_name,e.event_date,e.location,e.description,e.logo_url,e.non_qrcode_event FROM tickets t JOIN events e ON t.event_id=e.id WHERE t.ticket_code=?");
-        $st->execute([$code]);
-        $tk = $st->fetch();
-        if (!$tk) { http_response_code(404); echo 'Ticket introuvable'; exit; }
+        $codesRaw = trim((string)($_GET['codes'] ?? ''));
+        if ($codesRaw !== '') {
+            $codes = array_values(array_unique(array_filter(array_map(
+                fn($c) => strtoupper(trim((string)$c)),
+                explode(',', $codesRaw)
+            ))));
+        } else {
+            $single = strtoupper(trim((string)($_GET['code'] ?? '')));
+            $codes = $single !== '' ? [$single] : [];
+        }
+
+        if (!$codes) { http_response_code(400); echo 'Code manquant'; exit; }
+        $codes = array_slice($codes, 0, 100);
+
+        $ph = implode(',', array_fill(0, count($codes), '?'));
+        $sql = "SELECT t.*,e.name AS event_name,e.event_date,e.location,e.description,e.logo_url,e.non_qrcode_event
+                FROM tickets t
+                JOIN events e ON t.event_id=e.id
+                WHERE t.ticket_code IN ($ph)";
+        $st = $db->prepare($sql);
+        $st->execute($codes);
+        $rows = $st->fetchAll();
+        if (!$rows) { http_response_code(404); echo 'Ticket introuvable'; exit; }
+
+        $byCode = [];
+        foreach ($rows as $r) {
+            $byCode[strtoupper((string)$r['ticket_code'])] = $r;
+        }
+        $tickets = [];
+        foreach ($codes as $c) {
+            if (isset($byCode[$c])) {
+                $tickets[] = $byCode[$c];
+            }
+        }
+        if (!$tickets) { http_response_code(404); echo 'Ticket introuvable'; exit; }
+
         header('Content-Type: text/html; charset=utf-8');
         require __DIR__ . '/ticket_template.php';
         exit;

--- a/ticket_template.php
+++ b/ticket_template.php
@@ -1,179 +1,132 @@
 <?php
-/** @var array $tk — ticket + event data */
+/** @var array $tickets */
 $h = fn($s) => htmlspecialchars((string)($s ?? ''), ENT_QUOTES, 'UTF-8');
-$evN   = $h($tk['event_name']);
-$evSub = implode('  —  ', array_filter([$tk['event_date'] ?? '', $tk['location'] ?? '']));
-$evSub = $h($evSub);
-$desc  = $h($tk['description'] ?? '');
-$logo  = $tk['logo_url'] ?? '';
-$name  = $h($tk['prenom'] . ' ' . $tk['nom']);
-$label = $h($tk['ticket_label']);
-$code  = $h($tk['ticket_code']);
-$nonQr = !empty($tk['non_qrcode_event']);
-$url   = SITE_URL;
+$tickets = isset($tickets) && is_array($tickets) ? array_values($tickets) : (isset($tk) ? [$tk] : []);
+$url = SITE_URL;
 ?>
 <!DOCTYPE html>
 <html lang="fr">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1.0">
-<title>Ticket — <?= $name ?></title>
-<?php if (!$nonQr): ?>
+<title>Tickets PDF</title>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
-<?php endif; ?>
 <style>
-@page { size: 160mm 110mm; margin: 0; }
+@page { size: A4 portrait; margin: 10mm; }
 * { box-sizing: border-box; margin: 0; padding: 0; }
-body {
-    font-family: Georgia, 'Times New Roman', serif;
-    background: #f5f0e6;
-    display: flex; justify-content: center; align-items: center;
-    min-height: 100vh;
-}
+body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #f3f3f3; color: #111; }
 .toolbar {
-    position: fixed; top: 0; left: 0; right: 0;
-    background: #1a1a1a; color: #fff; padding: 10px 20px;
-    text-align: center; z-index: 10; font-family: system-ui, sans-serif;
+    position: sticky; top: 0; left: 0; right: 0; z-index: 20;
+    background: #111; color: #fff; padding: 10px 16px; text-align: center;
 }
 .toolbar button {
     background: #c0392b; color: #fff; border: none; border-radius: 6px;
-    padding: 7px 18px; font-size: .88rem; cursor: pointer; margin: 0 4px;
+    padding: 8px 14px; font-size: .9rem; cursor: pointer;
 }
-.toolbar a {
-    color: #fff; opacity: .7; font-size: .82rem;
-    text-decoration: none; margin-left: 12px; font-family: system-ui;
-}
+.toolbar a { color: #fff; opacity: .75; margin-left: 12px; text-decoration: none; font-size: .85rem; }
 
+.sheet {
+    width: 190mm; min-height: 277mm; margin: 10mm auto; background: #fff;
+    border: 1px solid #ddd; padding: 6mm;
+    display: grid; grid-template-columns: 1fr; grid-auto-rows: 1fr; gap: 6mm;
+}
 .ticket {
-    width: 460px; background: #FFF8E7;
-    border-radius: 4px; overflow: hidden; margin-top: 56px;
-    box-shadow: 0 4px 20px rgba(0,0,0,.15);
-    border: 2px solid #D4A017;
-    position: relative;
+    border: 1.4mm solid #111; border-radius: 2mm; overflow: hidden;
+    min-height: 128mm; display: flex; flex-direction: column;
 }
-
-/* Corner stars */
-.ticket::before, .ticket::after {
-    content: '★'; position: absolute; color: #D4A017; font-size: 14px; z-index: 2;
+.ticket-head { background: #1a1a2e; color: #fff; padding: 6mm; text-align: center; }
+.ticket-head img { max-height: 16mm; max-width: 55mm; object-fit: contain; margin-bottom: 2mm; }
+.ticket-head .ev-name { font-size: 7mm; font-weight: 700; line-height: 1.1; }
+.ticket-head .ev-sub { font-size: 3.2mm; opacity: .85; margin-top: 1.5mm; }
+.ticket-head .ev-desc { font-size: 2.8mm; opacity: .8; margin-top: 1.8mm; }
+.ticket-main {
+    flex: 1; display: grid; grid-template-columns: 1fr 34mm; gap: 5mm;
+    align-items: center; padding: 6mm;
 }
-.ticket::before { top: 8px; left: 10px; }
-.ticket::after { top: 8px; right: 10px; }
-
-.band {
-    background: #1a1a2e;
-    padding: 20px 24px; color: #fff; text-align: center;
-    position: relative;
-}
-.band .logo-row {
-    margin-bottom: 8px;
-}
-.band .logo-row img {
-    max-height: 50px; max-width: 200px; object-fit: contain;
-}
-.band .ev-name {
-    font-size: 24px; font-weight: 700; letter-spacing: 1px;
-    text-shadow: 0 1px 3px rgba(0,0,0,.3);
-}
-.band .ev-sub {
-    font-size: 12px; opacity: .8; margin-top: 4px; font-family: system-ui, sans-serif;
-}
-.band .ev-desc {
-    font-size: 11px; opacity: .7; margin-top: 6px; font-style: italic;
-    font-family: system-ui, sans-serif; line-height: 1.4;
-    max-width: 380px; margin-left: auto; margin-right: auto;
-}
-
-/* Gold accent strip with stars */
-.accent {
-    height: 5px;
-    background: linear-gradient(90deg, #8B0000, #D4A017 30%, #D4A017 70%, #8B0000);
-}
-
-.stars-row {
-    text-align: center; color: #D4A017; font-size: 11px;
-    letter-spacing: 8px; padding: 6px 0 2px;
-}
-
-.body {
-    display: flex; padding: 16px 24px 12px; align-items: center; gap: 20px;
-}
-.info { flex: 1; }
-.info .lbl {
-    font-size: 9px; text-transform: uppercase; letter-spacing: 2px;
-    color: #999; margin-bottom: 3px; font-family: system-ui;
-}
-.info .guest-name {
-    font-size: 24px; font-weight: 700; color: #1a1a2e; line-height: 1.2;
-}
-.info .tnum {
-    font-size: 13px; color: #8B0000; margin-top: 6px; font-weight: 600;
-}
-
-.qr-box { text-align: center; flex-shrink: 0; }
-.qr-code {
-    font-family: 'Courier New', monospace; font-size: 8px;
-    color: #bbb; margin-top: 4px; letter-spacing: 1px;
-}
-
-.footer {
-    text-align: center; font-size: 9px; color: #bbb;
-    padding: 8px 16px; border-top: 1px dashed #D4A017;
-    font-family: system-ui; letter-spacing: .3px;
+.lbl { font-size: 2.7mm; letter-spacing: .4mm; text-transform: uppercase; color: #666; }
+.guest { font-size: 6.4mm; font-weight: 700; margin-top: 1.5mm; }
+.label { font-size: 4.1mm; color: #8B0000; margin-top: 2.2mm; font-weight: 700; }
+.qr-wrap { text-align: center; }
+.qr-code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 2.3mm; margin-top: 1.5mm; color: #666; word-break: break-all; }
+.ticket-foot {
+    border-top: .45mm dashed #888; text-align: center;
+    font-size: 2.8mm; color: #555; padding: 2.4mm;
 }
 
 @media print {
     .toolbar { display: none !important; }
-    body { background: #fff; align-items: flex-start; padding: 0; }
-    .ticket { box-shadow: none; margin: 0; }
+    body { background: #fff; }
+    .sheet { margin: 0 auto; border: none; page-break-after: always; }
+    .sheet:last-child { page-break-after: auto; }
 }
 </style>
 </head>
 <body>
 <div class="toolbar">
     <button onclick="window.print()">Imprimer / PDF</button>
-    <a href="<?= $url ?>">Retour au scanner</a>
+    <a href="<?= $h($url) ?>">Retour au scanner</a>
 </div>
-<div class="ticket">
-    <div class="band">
-<?php if ($logo): ?>
-        <div class="logo-row"><img src="<?= $h($logo) ?>" alt="Logo"></div>
-<?php endif; ?>
-        <div class="ev-name"><?= $evN ?></div>
-<?php if ($evSub): ?>
-        <div class="ev-sub"><?= $evSub ?></div>
-<?php endif; ?>
-<?php if ($desc): ?>
-        <div class="ev-desc"><?= $desc ?></div>
-<?php endif; ?>
-    </div>
-    <div class="accent"></div>
-    <div class="stars-row">★ ★ ★ ★ ★</div>
-    <div class="body">
-        <div class="info">
-            <div class="lbl">Invit&eacute;</div>
-            <div class="guest-name"><?= $name ?></div>
-            <div class="tnum">Ticket <?= $label ?></div>
+<?php
+$chunks = array_chunk($tickets, 2);
+foreach ($chunks as $page => $group):
+?>
+<div class="sheet">
+<?php foreach ($group as $i => $row):
+    $evN = $h($row['event_name'] ?? 'Évènement');
+    $evSub = implode('  —  ', array_filter([$row['event_date'] ?? '', $row['location'] ?? '']));
+    $evSub = $h($evSub);
+    $desc = $h($row['description'] ?? '');
+    $logo = $row['logo_url'] ?? '';
+    $name = $h(($row['prenom'] ?? '') . ' ' . ($row['nom'] ?? ''));
+    $label = $h($row['ticket_label'] ?? '');
+    $code = $h($row['ticket_code'] ?? '');
+    $nonQr = !empty($row['non_qrcode_event']);
+    $qrId = 'qr_' . $page . '_' . $i;
+?>
+    <article class="ticket">
+        <header class="ticket-head">
+            <?php if ($logo): ?><img src="<?= $h($logo) ?>" alt="Logo"><?php endif; ?>
+            <div class="ev-name"><?= $evN ?></div>
+            <?php if ($evSub): ?><div class="ev-sub"><?= $evSub ?></div><?php endif; ?>
+            <?php if ($desc): ?><div class="ev-desc"><?= $desc ?></div><?php endif; ?>
+        </header>
+        <div class="ticket-main">
+            <div>
+                <div class="lbl">Invité</div>
+                <div class="guest"><?= $name ?></div>
+                <div class="label">Ticket <?= $label ?></div>
+            </div>
+            <div class="qr-wrap">
+                <?php if (!$nonQr): ?>
+                    <div id="<?= $qrId ?>"></div>
+                    <div class="qr-code"><?= $code ?></div>
+                <?php endif; ?>
+            </div>
         </div>
-        <div class="qr-box">
-<?php if ($nonQr): ?>
-            
-<?php else: ?>
-            <div id="qr"></div>
-            <div class="qr-code"><?= $code ?></div>
-<?php endif; ?>
-        </div>
-    </div>
-    <div class="footer">★ Pr&eacute;sentez ce ticket &agrave; l'entr&eacute;e &mdash; 1 ticket = 1 entr&eacute;e ★</div>
+        <footer class="ticket-foot">Présentez ce ticket à l'entrée — 1 ticket = 1 entrée</footer>
+    </article>
+<?php endforeach; ?>
 </div>
-<?php if (!$nonQr): ?>
+<?php endforeach; ?>
+
 <script>
-new QRCode(document.getElementById('qr'), {
-    text: "<?= $code ?>",
-    width: 110, height: 110,
-    colorDark: "#1a1a2e", colorLight: "#FFF8E7",
-    correctLevel: QRCode.CorrectLevel.M
-});
+(function(){
+    <?php foreach ($chunks as $page => $group):
+        foreach ($group as $i => $row):
+            if (!empty($row['non_qrcode_event'])) { continue; }
+            $qrId = 'qr_' . $page . '_' . $i;
+            $code = json_encode((string)($row['ticket_code'] ?? ''));
+    ?>
+    new QRCode(document.getElementById('<?= $qrId ?>'), {
+        text: <?= $code ?>,
+        width: 122,
+        height: 122,
+        colorDark: '#111',
+        colorLight: '#fff',
+        correctLevel: QRCode.CorrectLevel.M
+    });
+    <?php endforeach; endforeach; ?>
+})();
 </script>
-<?php endif; ?>
 </body>
 </html>

--- a/tickets.html
+++ b/tickets.html
@@ -4,67 +4,62 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Tous les Tickets</title>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 <style>
 *{box-sizing:border-box;margin:0;padding:0}
-body{font-family:Georgia,'Times New Roman',serif;background:#f5f0e6}
-.bar{background:#1a1a1a;color:#fff;padding:14px 20px;text-align:center;position:sticky;top:0;z-index:10;font-family:system-ui,sans-serif}
-.bar h1{font-size:1rem;margin-bottom:6px}
-.bar button{background:#c0392b;color:#fff;border:none;border-radius:6px;padding:7px 18px;font-size:.88rem;cursor:pointer;margin:3px}
-.bar a{color:#fff;opacity:.7;font-size:.82rem;text-decoration:none;display:block;margin-top:6px}
-#info{font-size:.82rem;margin-top:4px;opacity:.8;font-family:system-ui}
-.wrap{padding:16px;display:flex;flex-wrap:wrap;justify-content:center;gap:16px}
-
-/* Ticket card - retro */
-.tk{
-    width:430px;background:#FFF8E7;border-radius:4px;
-    box-shadow:0 2px 10px rgba(0,0,0,.1);overflow:hidden;
-    position:relative;border:2px solid #D4A017;
-    page-break-inside:avoid;
-}
-.tk::before,.tk::after{content:'★';position:absolute;color:#D4A017;font-size:10px;z-index:2}
-.tk::before{top:6px;left:8px}.tk::after{top:6px;right:8px}
-
-.tk-band{background:#1a1a2e;padding:12px 14px;text-align:center;color:#fff}
-.tk-band .logo{max-height:30px;max-width:120px;object-fit:contain;margin-bottom:4px;display:block;margin-left:auto;margin-right:auto}
-.tk-band .en{font-size:15px;font-weight:700;letter-spacing:.5px}
-.tk-band .es{font-size:9px;opacity:.7;margin-top:2px;font-family:system-ui}
-.tk-band .ed{font-size:8px;opacity:.6;margin-top:3px;font-style:italic;font-family:system-ui;line-height:1.3}
-.tk-acc{height:3px;background:linear-gradient(90deg,#8B0000,#D4A017 30%,#D4A017 70%,#8B0000)}
-.tk-stars{text-align:center;color:#D4A017;font-size:8px;letter-spacing:6px;padding:4px 0 0}
-
-.tk-body{display:flex;padding:10px 14px 8px;align-items:center;gap:12px}
-.tk-info{flex:1}
-.tk-name{font-size:15px;font-weight:700;color:#1a1a2e}
-.tk-sub{font-size:10px;color:#8B0000;margin-top:2px;font-weight:600}
-
-.tk-qr{text-align:center;flex-shrink:0;width:90px}
-.tk-qr canvas{display:block;margin:0 auto}
-/* Do NOT hide img globally - JS will clean duplicates */
-.tk-code{font-family:monospace;font-size:7px;color:#bbb;margin-top:2px;text-align:center}
-
-.tk-foot{text-align:center;font-size:7px;color:#ccc;padding:5px;border-top:1px dashed #D4A017;font-family:system-ui}
-
-@media print{
-    .bar{display:none!important}
-    body{background:#fff}
-    .wrap{padding:0;gap:8px}
-    .tk{box-shadow:none;break-inside:avoid}
-}
+body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:#f5f0e6;color:#111}
+.bar{background:#1a1a1a;color:#fff;padding:14px 20px;text-align:center;position:sticky;top:0;z-index:10}
+.bar h1{font-size:1rem;margin-bottom:8px}
+.bar .row{display:flex;justify-content:center;gap:8px;align-items:center;flex-wrap:wrap}
+.bar button{background:#c0392b;color:#fff;border:none;border-radius:6px;padding:7px 14px;font-size:.88rem;cursor:pointer}
+.bar button.alt{background:#444}
+.bar a{color:#fff;opacity:.8;font-size:.82rem;text-decoration:none;display:block;margin-top:8px}
+#info{font-size:.82rem;margin-top:6px;opacity:.85}
+.wrap{padding:16px;max-width:1100px;margin:0 auto}
+.card{background:#fff;border:1px solid #ddd;border-radius:10px;overflow:hidden}
+.table{width:100%;border-collapse:collapse}
+.table th,.table td{padding:10px;border-bottom:1px solid #eee;text-align:left;font-size:.92rem}
+.table th{background:#fafafa;font-size:.83rem;text-transform:uppercase;letter-spacing:.03em;color:#555}
+.table tr:hover td{background:#fcfcfc}
+.actions{display:flex;gap:6px;flex-wrap:wrap}
+.btn-link{background:#1a1a2e;color:#fff;text-decoration:none;padding:6px 10px;border-radius:6px;font-size:.8rem}
+.small{font-size:.8rem;color:#666}
 </style>
 </head>
 <body>
 <div class="bar">
   <h1>Tous les Tickets</h1>
-  <button onclick="window.print()">Imprimer / PDF</button>
-  <button onclick="load()">Recharger</button>
-  <select id="ev-sel" onchange="onEventChange()" style="margin-left:8px;padding:6px 8px;border-radius:6px;border:none;max-width:280px"></select>
+  <div class="row">
+    <select id="ev-sel" onchange="onEventChange()" style="padding:7px 9px;border-radius:6px;border:none;max-width:320px"></select>
+    <button onclick="openSelectedPdf()">PDF sélection</button>
+    <button class="alt" onclick="openAllPdf()">PDF tous</button>
+    <button class="alt" onclick="toggleAll(true)">Tout cocher</button>
+    <button class="alt" onclick="toggleAll(false)">Tout décocher</button>
+    <button class="alt" onclick="load()">Recharger</button>
+  </div>
   <div id="info">Chargement...</div>
   <a href="admin.html">Admin</a>
 </div>
-<div class="wrap" id="wrap"><div style="padding:40px;color:#888;font-family:system-ui">Chargement...</div></div>
+<div class="wrap">
+  <div class="card">
+    <table class="table">
+      <thead>
+        <tr>
+          <th><input type="checkbox" id="master" onchange="onMasterChange(this.checked)"></th>
+          <th>Nom</th>
+          <th>Ticket</th>
+          <th>Code</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody id="rows"><tr><td colspan="5" class="small" style="padding:20px">Chargement...</td></tr></tbody>
+    </table>
+  </div>
+</div>
 <script>
 var A='api.php',eid=parseInt(new URLSearchParams(location.search).get('event_id')||localStorage.getItem('lt_event_id')||'0',10)||0;
+var current=[];
+
+function esc(s){var d=document.createElement('div');d.textContent=String(s||'');return d.innerHTML;}
 
 function loadEvents(){
   return fetch(A+'?action=events').then(function(r){return r.json();}).then(function(events){
@@ -76,7 +71,7 @@ function loadEvents(){
     }
     sel.innerHTML=events.map(function(e){return '<option value="'+e.id+'">'+esc(e.name)+'</option>';}).join('');
     var found=events.find(function(e){return parseInt(e.id,10)===eid;});
-    if(!found){eid=parseInt(events[0].id,10);}
+    if(!found){eid=parseInt(events[0].id,10);}    
     sel.value=String(eid);
     localStorage.setItem('lt_event_id',String(eid));
     return true;
@@ -89,51 +84,61 @@ function load(){
     fetch(A+'?action=event&event_id='+eid).then(function(r){return r.json();}),
     fetch(A+'?action=guests&event_id='+eid).then(function(r){return r.json();})
   ]).then(function(res){
-    var ev=res[0],gs=res[1],w=document.getElementById('wrap');
-    w.innerHTML='';
-    if(!gs.length){w.innerHTML='<div style="padding:40px;color:#888;font-family:system-ui">Aucun ticket.</div>';document.getElementById('info').textContent='0';return;}
-    document.getElementById('info').textContent=gs.length+' tickets — '+esc(ev.name||'');
-    var name=ev.name||'Evenement';
-    var sub=[ev.event_date,ev.location].filter(Boolean).join('  —  ');
-    var desc=ev.description||'';
-    var logo=ev.logo_url||'';
+    var ev=res[0],gs=res[1],rows=document.getElementById('rows');
+    current=gs||[];
+    document.getElementById('master').checked=false;
 
-    gs.forEach(function(g,idx){
-      var d=document.createElement('div');d.className='tk';
-      var logoHtml=logo?'<img class="logo" src="'+esc(logo)+'" alt="">':'';
-      var descHtml=desc?'<div class="ed">'+esc(desc)+'</div>':'';
-      var qrId='qr'+idx;
-      var code = String(g.ticket_code||'');
-      var isNonQr=(parseInt(ev.non_qrcode_event,10)||0)===1;
-      d.innerHTML=
-        '<div class="tk-band">'+logoHtml+'<div class="en">'+esc(name)+'</div>'
-        +(sub?'<div class="es">'+esc(sub)+'</div>':'')
-        +descHtml+'</div>'
-        +'<div class="tk-acc"></div>'
-        +'<div class="tk-stars">★ ★ ★ ★ ★</div>'
-        +'<div class="tk-body">'
-        +'<div class="tk-info"><div class="tk-name">'+esc(g.prenom)+' '+esc(g.nom)+'</div><div class="tk-sub">Ticket '+esc(g.ticket_label)+'</div></div>'
-        +'<div class="tk-qr">' + (isNonQr ? '' : '<div id="'+qrId+'"></div><div class="tk-code">'+esc(code)+'</div>') + '</div>'
-        +'</div>'
-        +'<div class="tk-foot">★ 1 ticket = 1 entree ★</div>';
-      w.appendChild(d);
+    if(!current.length){
+      rows.innerHTML='<tr><td colspan="5" class="small" style="padding:20px">Aucun ticket.</td></tr>';
+      document.getElementById('info').textContent='0 ticket — '+esc(ev.name||'');
+      return;
+    }
 
-      if(!isNonQr){
-        new QRCode(document.getElementById(qrId),{
-          text:code, width:80, height:80,
-          colorDark:'#1a1a2e', colorLight:'#FFF8E7',
-          correctLevel:QRCode.CorrectLevel.M
-        });
-      }
-    });
+    document.getElementById('info').textContent=current.length+' tickets — '+esc(ev.name||'');
+    rows.innerHTML=current.map(function(g,idx){
+      var code=encodeURIComponent(g.ticket_code||'');
+      return '<tr>'
+        +'<td><input type="checkbox" class="ck" data-code="'+esc(g.ticket_code)+'"></td>'
+        +'<td>'+esc(g.prenom)+' '+esc(g.nom)+'</td>'
+        +'<td>'+esc(g.ticket_label)+'</td>'
+        +'<td><code>'+esc(g.ticket_code)+'</code></td>'
+        +'<td class="actions">'
+        +'<a class="btn-link" target="_blank" rel="noopener" href="api.php?action=ticket_pdf&code='+code+'">PDF</a>'
+        +'</td></tr>';
+    }).join('');
   });
 }
+
+function selectedCodes(){
+  return Array.from(document.querySelectorAll('.ck:checked')).map(function(c){return c.getAttribute('data-code');});
+}
+
+function openSelectedPdf(){
+  var codes=selectedCodes();
+  if(!codes.length){alert('Selectionnez au moins un ticket.');return;}
+  var q='api.php?action=ticket_pdf&codes='+encodeURIComponent(codes.join(','));
+  window.open(q,'_blank','noopener');
+}
+
+function openAllPdf(){
+  if(!current.length){alert('Aucun ticket.');return;}
+  var codes=current.map(function(g){return g.ticket_code;});
+  var q='api.php?action=ticket_pdf&codes='+encodeURIComponent(codes.join(','));
+  window.open(q,'_blank','noopener');
+}
+
+function toggleAll(v){
+  document.querySelectorAll('.ck').forEach(function(c){c.checked=v;});
+  document.getElementById('master').checked=v;
+}
+function onMasterChange(v){toggleAll(v);}
+
 function onEventChange(){
   eid=parseInt(document.getElementById('ev-sel').value,10)||0;
   localStorage.setItem('lt_event_id',String(eid));
   load();
 }
-function esc(s){var d=document.createElement('div');d.textContent=s;return d.innerHTML;}
+
 loadEvents().then(function(ok){if(ok)load();});
 </script>
 </body>


### PR DESCRIPTION
### Motivation
- Garantir que l'impression/PDF des tickets soit identique quel que soit l'endroit d'où on l'ouvre (scanner, liste, tous les tickets). 
- Permettre d'imprimer plusieurs tickets sur une même page A4 portrait pour faciliter l'impression et la mise en page.

### Description
- Unifie la génération PDF en réutilisant un seul template `ticket_template.php` pour les cas unitaires et batch, et adapte le rendu pour du A4 portrait avec bordures d'impression et mise en page print-safe (2 tickets par page via `array_chunk`).
- Étend l'endpoint `api.php?action=ticket_pdf` pour accepter `code` (unique) ou `codes` (CSV de codes) et restituer les tickets dans l'ordre demandé, avec une limite de 100 codes par requête pour éviter des pages/URLs trop volumineuses.
- Remplace/rafraîchit la page de liste `tickets.html` pour offrir une sélection par case à cocher, des boutons `PDF sélection` et `PDF tous` et un lien PDF unitaire par ticket, qui invoquent désormais le même flux de génération.
- Ajuste la génération des QR codes côté template pour supporter plusieurs tickets par page et respecter l'option `non_qrcode_event` des événements.

### Testing
- Vérification de syntaxe PHP réalisée avec `php -l api.php` et `php -l ticket_template.php`, les deux fichiers sont valides et ont renvoyé « No syntax errors detected ». 
- Aucun test d'interface graphique automatisé n'a été exécuté dans cet environnement (aucun navigateur headless automatisé disponible), la fonctionnalité batch est limitée à 100 codes pour tenir compte des contraintes pratiques des URLs/pages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90e9f72a883268854a881d521238c)